### PR TITLE
 Build support for 32-bit armv8-a

### DIFF
--- a/cc/config/arm_device.go
+++ b/cc/config/arm_device.go
@@ -102,6 +102,11 @@ var (
 			"-mfloat-abi=softfp",
 			"-mfpu=neon",
 		},
+		"armv8-a": []string{
+			"-march=armv8-a",
+			"-mfloat-abi=softfp",
+			"-mfpu=neon-fp-armv8",
+		},
 	}
 
 	armCpuVariantCflags = map[string][]string{
@@ -171,6 +176,7 @@ func init() {
 		"armv5te",
 		"armv7-a",
 		"armv7-a-neon",
+		"armv8-a",
 		"cortex-a7",
 		"cortex-a8",
 		"cortex-a9",
@@ -183,11 +189,18 @@ func init() {
 		"denver")
 
 	android.RegisterArchVariantFeatures(android.Arm, "armv7-a-neon", "neon")
+	android.RegisterArchVariantFeatures(android.Arm, "armv8-a", "neon")
 
 	// Krait and Kryo targets are not supported by GCC, but are supported by Clang,
 	// so override the definitions when building modules with Clang.
 	replaceFirst(armClangCpuVariantCflags["krait"], "-mcpu=cortex-a15", "-mcpu=krait")
 	replaceFirst(armClangCpuVariantCflags["kryo"], "-mcpu=cortex-a15", "-mcpu=krait")
+
+	// The reason we use "-march=armv8-a+crc", instead of "-march=armv8-a", for
+	// gcc is the latter would conflict with any specified/supported -mcpu!
+	// All armv8-a cores supported by gcc 4.9 support crc, so it's safe
+	// to add +crc. Besides, the use of gcc is only for legacy code.
+	replaceFirst(armArchVariantCflags["armv8-a"], "-march=armv8-a", "-march=armv8-a+crc")
 
 	pctx.StaticVariable("armGccVersion", armGccVersion)
 
@@ -210,6 +223,7 @@ func init() {
 	pctx.StaticVariable("ArmArmv5TECflags", strings.Join(armArchVariantCflags["armv5te"], " "))
 	pctx.StaticVariable("ArmArmv7ACflags", strings.Join(armArchVariantCflags["armv7-a"], " "))
 	pctx.StaticVariable("ArmArmv7ANeonCflags", strings.Join(armArchVariantCflags["armv7-a-neon"], " "))
+	pctx.StaticVariable("ArmArmv8ACflags", strings.Join(armArchVariantCflags["armv8-a"], " "))
 
 	// Cpu variant cflags
 	pctx.StaticVariable("ArmGenericCflags", strings.Join(armCpuVariantCflags[""], " "))
@@ -237,6 +251,8 @@ func init() {
 		strings.Join(armClangArchVariantCflags["armv7-a"], " "))
 	pctx.StaticVariable("ArmClangArmv7ANeonCflags",
 		strings.Join(armClangArchVariantCflags["armv7-a-neon"], " "))
+	pctx.StaticVariable("ArmClangArmv8ACflags",
+		strings.Join(armClangArchVariantCflags["armv8-a"], " "))
 
 	// Clang cpu variant cflags
 	pctx.StaticVariable("ArmClangGenericCflags",
@@ -260,6 +276,7 @@ var (
 		"armv5te":      "${config.ArmArmv5TECflags}",
 		"armv7-a":      "${config.ArmArmv7ACflags}",
 		"armv7-a-neon": "${config.ArmArmv7ANeonCflags}",
+		"armv8-a":      "${config.ArmArmv8ACflags}",
 	}
 
 	armCpuVariantCflagsVar = map[string]string{
@@ -279,6 +296,7 @@ var (
 		"armv5te":      "${config.ArmClangArmv5TECflags}",
 		"armv7-a":      "${config.ArmClangArmv7ACflags}",
 		"armv7-a-neon": "${config.ArmClangArmv7ANeonCflags}",
+		"armv8-a":      "${config.ArmClangArmv8ACflags}",
 	}
 
 	armClangCpuVariantCflagsVar = map[string]string{
@@ -393,6 +411,11 @@ func armToolchainFactory(arch android.Arch) Toolchain {
 	toolchainClangCflags[0] = "${config.ArmToolchainClangCflags}"
 	toolchainClangCflags[1] = armClangArchVariantCflagsVar[arch.ArchVariant]
 
+	toolchainCflags = append(toolchainCflags,
+		variantOrDefault(armCpuVariantCflagsVar, arch.CpuVariant))
+	toolchainClangCflags = append(toolchainClangCflags,
+		variantOrDefault(armClangCpuVariantCflagsVar, arch.CpuVariant))
+
 	switch arch.ArchVariant {
 	case "armv7-a-neon":
 		switch arch.CpuVariant {
@@ -402,15 +425,12 @@ func armToolchainFactory(arch android.Arch) Toolchain {
 		default:
 			fixCortexA8 = "-Wl,--no-fix-cortex-a8"
 		}
-
-		toolchainCflags = append(toolchainCflags,
-			variantOrDefault(armCpuVariantCflagsVar, arch.CpuVariant))
-		toolchainClangCflags = append(toolchainClangCflags,
-			variantOrDefault(armClangCpuVariantCflagsVar, arch.CpuVariant))
 	case "armv7-a":
 		fixCortexA8 = "-Wl,--fix-cortex-a8"
 	case "armv5te":
 		// Nothing extra for armv5te
+	case "armv8-a":
+		// Nothing extra for armv8-a
 	default:
 		panic(fmt.Sprintf("Unknown ARM architecture version: %q", arch.ArchVariant))
 	}

--- a/cc/config/arm_device.go
+++ b/cc/config/arm_device.go
@@ -98,15 +98,13 @@ var (
 			"-mfpu=vfpv3-d16",
 		},
 		"armv7-a-neon": []string{
+			"-march=armv7-a",
 			"-mfloat-abi=softfp",
 			"-mfpu=neon",
 		},
 	}
 
 	armCpuVariantCflags = map[string][]string{
-		"": []string{
-			"-march=armv7-a",
-		},
 		"cortex-a7": []string{
 			"-mcpu=cortex-a7",
 			"-mfpu=neon-vfpv4",


### PR DESCRIPTION
Build support for 32-bit armv8-a

Add armv8-a as a valid/supported 32-bit arm architecture variant. If
some known armv8-a core, like cortex-a53, cortex-a73, etc. is specified
as TARGET(_2ND)_CPU_VARIANT, the associated TARGET(_2ND)_ARCH_VARIANT
will be treated as if armv8-a is specified.

Bug: 62895439
Test: "bionic-unit-tests-static --gtest_filter=*strlen*" on Nexus 4
      (armv7-krait), emulator (armv7), and sailfish (armv8-kryo).
      The test binary for the first 2 is built with armv7-a as its
      TARGET_ARCH_VARIANT; The test binary for the last is built with
      armv8-a as its TARGET_2ND_ARCH_VARIANT.
      TARGET(_2ND)_CPU_VARIANTs of both binaries are set to "generic".

Change-Id: I53bee2974346cf485b2da54cf7aad010b0425910

Generic 32-bit armv8 built as generic armv7 fix

When the following lines are specified in the BoardConfig.mk

TARGET_2ND_ARCH_VARIANT := armv8-a
TARGET_2ND_CPU_VARIANT := generic

The resulted binaries won't be built using 32-bit armv8-a integer
division instructions. Instead, division routines are used because
the build system will set a compiler option "-march=armv7-a", and
hence overwiting the previous "-march=armv8-a", when
TARGET_2ND_CPU_VARIANT is set to generic (or unset).

Bug: 67446726
Test: lunch aosp_arm64; make -j; emulator # boot to home screen
      Also verify -march=armv7-a is not specified in the compiler
      command line and the resulted binary actually uses integer
      division instructions.

Change-Id: I430687aa5a658d2ec9f325a66d849b4c8898c7d5